### PR TITLE
Deployment fix - added `command` field in manfiest.yml.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ applications:
   memory: 256M
   instances: 1
   random-route: true
+  command: Server
   services:
   - TodoListCloudantDatabase
 


### PR DESCRIPTION
- Fix for deployment of app in Bluemix.
  - Needed to add `command` to the root manifest.yml file.